### PR TITLE
[shadow] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/shadow-utils.spec
+++ b/rpm/shadow-utils.spec
@@ -15,6 +15,7 @@ BuildRequires: gettext-devel
 BuildRequires: automake
 BuildRequires: libtool
 BuildRequires: byacc
+BuildRequires: pkgconfig(libcrypt)
 
 %description
 The shadow-utils package includes the necessary programs for


### PR DESCRIPTION
shadow-utils depdends on pkconfig(libcrypt) for the crypt import but it was
not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.