### PR TITLE
Introduce devel package JB#62498

### DIFF
--- a/rpm/shadow-utils.spec
+++ b/rpm/shadow-utils.spec
@@ -34,6 +34,12 @@ for all users. The useradd, userdel, and usermod commands are used for
 managing user accounts. The groupadd, groupdel, and groupmod commands
 are used for managing group accounts.
 
+%package devel
+Summary: The shadow-utils subid developer package
+
+%description devel
+The shadow-utils subid developer files
+
 %prep
 %autosetup -p1 -n %{name}-%{version}/upstream
 
@@ -83,10 +89,6 @@ rm $RPM_BUILD_ROOT/%{_sbindir}/logoutd
 rm $RPM_BUILD_ROOT/%{_sbindir}/nologin
 rm $RPM_BUILD_ROOT/%{_sbindir}/chgpasswd
 
-# Remove libsuid(-devel) files
-rm $RPM_BUILD_ROOT/%{_includedir}/shadow/subid.h
-rm $RPM_BUILD_ROOT/%{_libdir}/libsubid.a
-
 %files
 %license gpl-2.0.txt shadow-bsd.txt
 %dir %{_sysconfdir}/default
@@ -96,3 +98,7 @@ rm $RPM_BUILD_ROOT/%{_libdir}/libsubid.a
 %{_sbindir}/*
 %attr(0750,root,root)   %{_sbindir}/user*
 %attr(0750,root,root)   %{_sbindir}/group*
+
+%files devel
+%{_includedir}/shadow/subid.h
+%{_libdir}/libsubid.a


### PR DESCRIPTION
Don't remove the .h and .a files, but package them in `shadow-utils-devel` package instead. This is then required in building [libshadowutils#2](https://github.com/sailfishos/libshadowutils/pull/2) after the last commit, which fixes the remaining compiler warnings for the package.